### PR TITLE
admin file is identified by Province_State alone

### DIFF
--- a/data_tables/vaccine_data/us_data/readme.md
+++ b/data_tables/vaccine_data/us_data/readme.md
@@ -3,7 +3,7 @@
 ## Files in this folder
 
 - time_series/vaccine_data_us_timeline.csv: Contains historical data, updated once a day. Each row is uniquely defined by `Province_State`, `Date`, and `Vaccine_Type`. Long format.
-- time_series_covid19_vaccine_doses_admin_US.csv: Contains historical data, updated once a day. Each row is uniquely defined by `Province_State`, `Date`, and `Vaccine_Type`. Wide format.
+- time_series_covid19_vaccine_doses_admin_US.csv: Contains historical data, updated once a day. Each row is uniquely defined by `Province_State`. Wide format.
 - hourly/vaccine_data_us.csv: Contains the most recent data collected for each region, updated hourly. Each row is uniquely identified by `Province_State` and `Vaccine_Type`
 - data_dictionary.csv: Metric definitions
 - readme.md: This file. Description of contents and list of data sources


### PR DESCRIPTION
The description of the `time_series_covid19_vaccine_doses_admin_US.csv` file is incorrect. The file is "wide format", so there is only one row per jurisdiction, not one per jurisdiction:date:type tuple.